### PR TITLE
Replace the kurucz hdfstore with the newer version

### DIFF
--- a/test_hdfstores/kurucz_cd23_chianti_H_He.zip
+++ b/test_hdfstores/kurucz_cd23_chianti_H_He.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0a88c5e231ee49a4c67b66b1b3270ec9d2b6254e4af6bd8bcb81624b59f98884
-size 58909480
+oid sha256:09f4e4ad5c3a93b748a3e6aad20ea789dede480267a9b0d30d0c90ac7d5f0cfe
+size 32894562


### PR DESCRIPTION
In the new hdfstore lines are filtered on the loggf threshold
