### PR TITLE
Add levels and lines for Si II from kurucz gfall

### DIFF
--- a/test_databases/test.db
+++ b/test_databases/test.db
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f1c2746a1521fd1a05b446e9a804c116728c4ddf1e54b310ded71ee7cfdde0d
-size 245760
+oid sha256:9344086b9e8eaf26bf3d8ab83cf7e4c5161d7149d716ea270d11dffc2ae737a6
+size 347136

--- a/test_databases/test_db.rst
+++ b/test_databases/test_db.rst
@@ -1,0 +1,14 @@
+***************************
+Test Database Description
+***************************
+The database is used for testing purposes and contains the following:
+
+1. Atomic weights (masses) from  `NIST Atomic Weights and Isotopic Compositions <http://www.nist.gov/pml/data/comp.cfm>`_
+   for common atoms
+2. Ionization energies and ground levels from
+   `NIST Atomic Spectra Database <http://physics.nist.gov/PhysRefData/ASD/ionEnergy.html>`_
+   for the following ions: H-Zn
+3. Levels and lines from `Kurucz <http://kurucz.harvard.edu/linelists/gfall/>`_
+   for the following ions: Be III, B IV, N VI, Si II
+4. Levels and lines from `CHIANTI v 8.0.2 <http://www.chiantidatabase.org/chianti_download.html>`_
+   for the following ions: He II, N VI


### PR DESCRIPTION
This PR:
-  adds levels and lines for Si II from kurucz gfall to test.db
  - adds a description for test.db
